### PR TITLE
Fix for flaky playwright tests

### DIFF
--- a/frontend/src/components/AddToCartButton/AddToCartButton.js
+++ b/frontend/src/components/AddToCartButton/AddToCartButton.js
@@ -10,7 +10,7 @@ const AddToCartButton = ({ onClick, disabled, children }) => {
           : 'bg-gray-300 text-gray-500 cursor-not-allowed'
       }`}
       disabled={disabled}
-      data-testid="add-to-cart-button"
+      data-testid={disabled ? 'out-of-stock-button' : 'add-to-cart-button'}
     >
       {children}
     </button>


### PR DESCRIPTION
There was a situation where tests might be flaky, its because we're creating products' price and stocks randomly. Sometimes some products can become out of stock and e2e tests are still trying to click that disabled button.

So I adjusted the data-testid for Add To Cart Button to be dynamic regarding if the button is disabled or not.